### PR TITLE
Fix date display in transactions

### DIFF
--- a/appli.py
+++ b/appli.py
@@ -220,6 +220,9 @@ if uploaded_file:
         st.subheader("Liste des transactions carte filtrées")
         depenses_par_carte = df_filtered[df_filtered["Montant"] < 0].copy()
         depenses_par_carte = depenses_par_carte.sort_values("Date")
+        # Format de la date sans l'heure pour l'affichage
+        if pd.api.types.is_datetime64_any_dtype(depenses_par_carte["Date"]):
+            depenses_par_carte["Date"] = depenses_par_carte["Date"].dt.strftime("%Y-%m-%d")
         total_depenses_carte = abs(depenses_par_carte["Montant"].sum())
         st.markdown(f"**Total des dépenses par carte : {total_depenses_carte:,.2f} €**")
         st.dataframe(


### PR DESCRIPTION
## Summary
- format the `Date` column without hours in the transactions tab

## Testing
- `python -m py_compile appli.py`


------
https://chatgpt.com/codex/tasks/task_e_6849ab9d16fc8331b1f251e530d7d8a9