### PR TITLE
Default dark mode for streamlit app

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,7 +1,7 @@
 [theme]
-base="light"
+base="dark"
 primaryColor="#0066cc"
-backgroundColor="#ffffff"
-secondaryBackgroundColor="#f5f5f5"
-textColor="#262730"
+backgroundColor="#0e1117"
+secondaryBackgroundColor="#262730"
+textColor="#fafafa"
 font="sans serif"


### PR DESCRIPTION
## Summary
- switch the Streamlit theme to dark in `config.toml`

## Testing
- `None`

------
https://chatgpt.com/codex/tasks/task_e_6849aefa4a5c8331b4743d97b05f0870