### PR TITLE
Improve card transaction detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Launch the application with:
 streamlit run appli.py
 ```
 
+The application automatically filters transactions whose type contains the word
+"carte" (case insensitive) to display card expenses only.
+
 ## Deploy on share.streamlit.io
 
 On share.streamlit.io, create a new deployment and set **appli.py** as the entry point. The platform will read `requirements.txt` to install the dependencies automatically.

--- a/appli.py
+++ b/appli.py
@@ -33,7 +33,7 @@ st.markdown(
 # --- UPLOAD ---
 with st.sidebar:
     st.header("🗂 Import du relevé")
-    st.info("Seules les transactions dont le Type est 'Transaction par carte' seront conservées.")
+    st.info("Seules les transactions dont le type contient 'carte' seront conservées.")
 
 st.markdown("<div class='step-title'>1️⃣ Importez un relevé PDF</div>", unsafe_allow_html=True)
 uploaded_file = st.file_uploader("Choisissez un relevé de compte (PDF)", type=["pdf"])
@@ -156,8 +156,8 @@ if uploaded_file:
         df["Date"] = pd.to_datetime(df["Date"], errors='coerce')
     df = df.dropna(subset=["Date"])
 
-    # --- FILTRAGE : Transactions par carte uniquement ---
-    df = df[df["Type"].str.strip() == "Transaction par carte"].copy()
+    # --- FILTRAGE : Transactions carte ---
+    df = df[df["Type"].str.contains("carte", case=False, na=False)].copy()
     if df.empty:
         st.warning("Aucune transaction par carte trouvée sur ce relevé.")
         st.stop()


### PR DESCRIPTION
## Summary
- look for the word *carte* when filtering card transactions
- update sidebar info message
- document card transaction filtering in README

## Testing
- `python -m py_compile appli.py`


------
https://chatgpt.com/codex/tasks/task_e_6849af2105b08331a7c0ae38baec8b10