### PR TITLE
Add conditional formatting for Montant overview

### DIFF
--- a/appli.py
+++ b/appli.py
@@ -183,6 +183,11 @@ if uploaded_file:
     )
     df_filtered = df[mask].copy().reset_index(drop=True)
 
+    # Common style helper for Montant columns
+    def color_montant(val):
+        color = "red" if val < 0 else "green"
+        return f"color: {color}"
+
     # --------- Onglets principaux ---------
     tab1, tab2, tab3 = st.tabs(
         ["🏠 Aperçu général", "💳 Transactions", "📊 Visualisations"]
@@ -213,7 +218,12 @@ if uploaded_file:
             .sort_values(ascending=False)
             .reset_index()
         )
-        st.dataframe(resume, use_container_width=True, height=200)
+
+        styled_resume = (
+            resume.style.applymap(color_montant, subset=["Montant"])
+            .format({"Montant": "{:+,.2f} €"})
+        )
+        st.dataframe(styled_resume, use_container_width=True, height=200)
 
     # ----- 2. Transactions -----
     with tab2:
@@ -226,10 +236,6 @@ if uploaded_file:
         total_depenses_carte = abs(depenses_par_carte["Montant"].sum())
         st.markdown(f"**Total des dépenses par carte : {total_depenses_carte:,.2f} €**")
         # Style montant column: red for negatives, green for positives
-        def color_montant(val):
-            color = "red" if val < 0 else "green"
-            return f"color: {color}"
-
         depenses_par_carte = depenses_par_carte.reset_index(drop=True)
         depenses_par_carte.index += 1
         styled_df = (


### PR DESCRIPTION
## Summary
- color Montant values in both overview and transaction tabs
- reuse `color_montant` styling helper across tabs

## Testing
- `python -m py_compile appli.py`


------
https://chatgpt.com/codex/tasks/task_e_6849b9af12a8833195ec4c192c0d1ae9