### PR TITLE
Remove card summary subheader

### DIFF
--- a/appli.py
+++ b/appli.py
@@ -191,7 +191,6 @@ if uploaded_file:
 
     # ----- 1. Aperçu général -----
     with tab1:
-        st.subheader("Synthèse dépenses carte (période filtrée)")
 
         if df_filtered.empty:
             st.warning("Aucune transaction ne correspond aux filtres sélectionnés.")


### PR DESCRIPTION
## Summary
- remove the redundant subheader in the general overview tab

## Testing
- `python -m py_compile appli.py`

------
https://chatgpt.com/codex/tasks/task_e_6849bc510ff883318fc0b1f97b3343c3