### PR TITLE
Remove final balance metric

### DIFF
--- a/appli.py
+++ b/appli.py
@@ -198,16 +198,7 @@ if uploaded_file:
             st.stop()
 
         total_dep = df_filtered[df_filtered["Montant"] < 0]["Montant"].sum()
-        solde_fin = (
-            df_filtered["Solde"].dropna().iloc[-1]
-            if df_filtered["Solde"].notna().any()
-            else df_filtered["Montant"].cumsum().iloc[-1]
-        )
-        col1, col2 = st.columns(2)
-        with col1:
-            st.metric("Total dépenses carte", f"{abs(total_dep):,.2f} €", delta=None)
-        with col2:
-            st.metric("Solde final (filtré)", f"{solde_fin:,.2f} €", delta=None)
+        st.metric("Total dépenses carte", f"{abs(total_dep):,.2f} €", delta=None)
 
         # Dépenses par description (tableau compact)
         st.markdown("**Dépenses par carte (par description)**")


### PR DESCRIPTION
## Summary
- remove display of the filtered final balance from the general overview

## Testing
- `python -m py_compile appli.py`


------
https://chatgpt.com/codex/tasks/task_e_6849bc8033a483318dca15c3a5e61e7f