### PR TITLE
Remove redundant transactions header

### DIFF
--- a/appli.py
+++ b/appli.py
@@ -224,7 +224,6 @@ if uploaded_file:
 
     # ----- 2. Transactions -----
     with tab2:
-        st.subheader("Liste des transactions carte filtrées")
         depenses_par_carte = df_filtered[df_filtered["Montant"] < 0].copy()
         depenses_par_carte = depenses_par_carte.sort_values("Date")
         # Format de la date sans l'heure pour l'affichage


### PR DESCRIPTION
## Summary
- remove `Liste des transactions carte filtrées` subheader from Transactions tab

## Testing
- `python -m py_compile appli.py`


------
https://chatgpt.com/codex/tasks/task_e_6849bd5cbc5c8331a89ccd7aae2c074e