### PR TITLE
Add expenses visualisation tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ streamlit run appli.py
 The application automatically filters transactions whose type contains the word
 "carte" (case insensitive) to display card expenses only.
 
+## Visualisation des dépenses
+
+Un onglet **Visualisation** affiche l'évolution des dépenses par carte dans le temps
+à l'aide d'un graphique interactif.
+
 ## Deploy on share.streamlit.io
 
 On share.streamlit.io, create a new deployment and set **appli.py** as the entry point. The platform will read `requirements.txt` to install the dependencies automatically.

--- a/appli.py
+++ b/appli.py
@@ -184,9 +184,10 @@ if uploaded_file:
     df_filtered = df[mask].copy().reset_index(drop=True)
 
     # --------- Onglets principaux ---------
-    tab1, tab2 = st.tabs([
+    tab1, tab2, tab3 = st.tabs([
         "🏠 Aperçu général",
         "💳 Transactions",
+        "📊 Visualisation",
     ])
 
     # ----- 1. Aperçu général -----
@@ -248,6 +249,28 @@ if uploaded_file:
             .format({"Montant": "{:+,.2f} €"})
         )
         st.dataframe(styled_df, use_container_width=True, height=460)
+
+    # ----- 3. Visualisation -----
+    with tab3:
+        if df_filtered.empty:
+            st.warning("Aucune transaction ne correspond aux filtres sélectionnés.")
+        else:
+            evolution = (
+                df_filtered[df_filtered["Montant"] < 0]
+                .groupby(df_filtered["Date"].dt.date)["Montant"]
+                .sum()
+                .abs()
+                .reset_index()
+            )
+            fig = px.line(
+                evolution,
+                x="Date",
+                y="Montant",
+                markers=True,
+                title="Évolution des dépenses dans le temps",
+            )
+            fig.update_layout(xaxis_title="Date", yaxis_title="Montant (€)")
+            st.plotly_chart(fig, use_container_width=True)
 
 else:
     st.info("Importez un relevé bancaire PDF pour démarrer l’analyse (étape 1).")


### PR DESCRIPTION
## Summary
- add a third *Visualisation* tab
- plot evolution of card expenses over time
- document the new tab in the README

## Testing
- `python -m py_compile appli.py`

------
https://chatgpt.com/codex/tasks/task_e_6849c59cfa7083319cddb6b7ac1120a0