### PR TITLE
Add cumulative spending visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ The application automatically filters transactions whose type contains the word
 
 ## Visualisation des dépenses
 
-Un onglet **Visualisation** affiche l'évolution des dépenses par carte dans le temps
-à l'aide d'un graphique interactif.
+Un onglet **Visualisation** affiche l'évolution **cumulée** des dépenses par carte
+dans le temps à l'aide d'un graphique interactif.
 
 ## Deploy on share.streamlit.io
 

--- a/appli.py
+++ b/appli.py
@@ -262,14 +262,15 @@ if uploaded_file:
                 .abs()
                 .reset_index()
             )
+            evolution["Montant cumulé"] = evolution["Montant"].cumsum()
             fig = px.line(
                 evolution,
                 x="Date",
-                y="Montant",
+                y="Montant cumulé",
                 markers=True,
-                title="Évolution des dépenses dans le temps",
+                title="Évolution cumulée des dépenses dans le temps",
             )
-            fig.update_layout(xaxis_title="Date", yaxis_title="Montant (€)")
+            fig.update_layout(xaxis_title="Date", yaxis_title="Montant cumulé (€)")
             st.plotly_chart(fig, use_container_width=True)
 
 else:


### PR DESCRIPTION
## Summary
- compute cumulative spending in the visualization tab
- show cumulative spending line chart
- document cumulative spending in the README

## Testing
- `python -m py_compile appli.py`

------
https://chatgpt.com/codex/tasks/task_e_6849ccbdfc2c8331a6fc5330e08b6cbe