### PR TITLE
Afficher moyenne dépenses journalière

### DIFF
--- a/appli.py
+++ b/appli.py
@@ -236,6 +236,11 @@ if uploaded_file:
             depenses_par_carte["Date"] = depenses_par_carte["Date"].dt.strftime("%d/%m/%Y")
         total_depenses_carte = abs(depenses_par_carte["Montant"].sum())
         st.markdown(f"**Total des dépenses par carte : {total_depenses_carte:,.2f} €**")
+        moyenne_journaliere = total_depenses_carte / 30.44
+        st.markdown(
+            f"<div class='sub'>Dépense moyenne quotidienne : {moyenne_journaliere:,.2f} €</div>",
+            unsafe_allow_html=True,
+        )
         # Style montant column: red for negatives, green for positives
         def color_montant(val):
             color = "red" if val < 0 else "green"


### PR DESCRIPTION
## Summary
- compute average daily spending using `total_depenses_carte / 30.44`
- display it in the Transactions tab under the total

## Testing
- `python -m py_compile appli.py`


------
https://chatgpt.com/codex/tasks/task_e_684a45f9b4ec833182cd83d260a8e7f7