### PR TITLE
Add copy description feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ The application automatically filters transactions whose type contains the word
 Un onglet **Visualisation** affiche l'évolution **cumulée** des dépenses par carte
 dans le temps à l'aide d'un graphique interactif.
 
+## Copier facilement les descriptions
+
+Dans l'onglet **Transactions**, un champ permet de sélectionner une ligne et
+d'afficher sa description avec un bouton de copie intégré. Vous pouvez ainsi
+copier le texte sans risque d'erreur.
+
 ## Deploy on share.streamlit.io
 
 On share.streamlit.io, create a new deployment and set **appli.py** as the entry point. The platform will read `requirements.txt` to install the dependencies automatically.

--- a/appli.py
+++ b/appli.py
@@ -255,6 +255,18 @@ if uploaded_file:
         )
         st.dataframe(styled_df, use_container_width=True, height=460)
 
+        if not depenses_par_carte.empty:
+            st.markdown("### Copier une description")
+            idx_to_copy = st.number_input(
+                "Sélectionnez la ligne de transaction pour copier la description",
+                min_value=1,
+                max_value=len(depenses_par_carte),
+                value=1,
+                step=1,
+            )
+            desc_to_copy = depenses_par_carte.loc[idx_to_copy - 1, "Description"]
+            st.code(desc_to_copy, language=None)
+
     # ----- 3. Visualisation -----
     with tab3:
         if df_filtered.empty:


### PR DESCRIPTION
## Summary
- add selection box to copy transaction descriptions with streamlit's copy button
- document how to use the new copy feature in the README

## Testing
- `python -m py_compile appli.py`

------
https://chatgpt.com/codex/tasks/task_e_684a472a21188331b51797c74f487ed6