### PR TITLE
Remove monthly view option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,12 @@ The application automatically filters transactions whose type contains the word
 
 ## Visualisation des dépenses
 
-L'onglet **Visualisation** propose désormais plusieurs modes :
+L'onglet **Visualisation** propose désormais deux modes :
 
 - **Évolution cumulée** des dépenses au fil du temps
 - **Dépenses par jour** pour voir les montants quotidiens
-- **Dépenses par mois** avec un total mensuel
 
-Un menu déroulant dans l'application permet de sélectionner la vue désirée.
+Un menu déroulant dans l'application permet de choisir la vue désirée.
 
 ## Deploy on share.streamlit.io
 

--- a/appli.py
+++ b/appli.py
@@ -263,7 +263,7 @@ if uploaded_file:
             st.subheader("Visualisation des dépenses")
             view_option = st.selectbox(
                 "Mode d'affichage",
-                ["Évolution cumulée", "Dépenses par jour", "Dépenses par mois"],
+                ["Évolution cumulée", "Dépenses par jour"],
             )
 
             base = df_filtered[df_filtered["Montant"] < 0].copy()
@@ -293,16 +293,6 @@ if uploaded_file:
                     title="Dépenses par jour",
                 )
                 fig.update_layout(xaxis_title="Date", yaxis_title="Montant (€)")
-            else:
-                base["Mois"] = base["Date"].dt.to_period("M").dt.to_timestamp()
-                monthly = base.groupby("Mois")["Montant"].sum().reset_index()
-                fig = px.bar(
-                    monthly,
-                    x="Mois",
-                    y="Montant",
-                    title="Dépenses par mois",
-                )
-                fig.update_layout(xaxis_title="Mois", yaxis_title="Montant (€)")
 
             st.plotly_chart(fig, use_container_width=True)
 


### PR DESCRIPTION
## Summary
- remove `Dépenses par mois` option in the visualization dropdown
- adjust README description of visualization modes

## Testing
- `python -m py_compile appli.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_684a9d233f1883318a079e44446586bc