### PR TITLE
Add average transaction amount column

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ streamlit run appli.py
 The application automatically filters transactions whose type contains the word
 "carte" (case insensitive) to display card expenses only.
 
+In the **Aperçu général** tab, the summary table now includes an additional
+column showing the average amount per transaction. This value is left blank
+when there is only a single transaction for a given description.
+
 ## Visualisation des dépenses
 
 L'onglet **Visualisation** propose désormais deux modes :

--- a/appli.py
+++ b/appli.py
@@ -209,8 +209,20 @@ if uploaded_file:
         )
         resume["Montant"] = resume["sum"].abs()
         resume["Nombre de transactions"] = resume["size"].astype(int)
+        resume["Montant moyen par transaction"] = resume.apply(
+            lambda r: r["Montant"] / r["Nombre de transactions"]
+            if r["Nombre de transactions"] > 1
+            else None,
+            axis=1,
+        )
         resume = (
-            resume[["Montant", "Nombre de transactions"]]
+            resume[
+                [
+                    "Montant",
+                    "Nombre de transactions",
+                    "Montant moyen par transaction",
+                ]
+            ]
             .sort_values("Montant", ascending=False)
             .reset_index()
         )
@@ -223,11 +235,12 @@ if uploaded_file:
         resume.index += 1
         format_dict = {
             "Montant": "{:,.2f} €",
-            "Nombre de transactions": "{:d}"
+            "Nombre de transactions": "{:d}",
+            "Montant moyen par transaction": "{:,.2f} €",
         }
         if "Pourcentage" in resume.columns:
             format_dict["Pourcentage"] = "{:.1f}%"
-        formatted_resume = resume.style.format(format_dict)
+        formatted_resume = resume.style.format(format_dict, na_rep="")
         st.dataframe(
             formatted_resume,
             use_container_width=True,


### PR DESCRIPTION
## Summary
- compute average amount per transaction in the overview table
- show the new value before the percentage column
- document the new column in the README
- leave the average blank when there's only one transaction

## Testing
- `python -m py_compile appli.py`


------
https://chatgpt.com/codex/tasks/task_e_684aa1cf981c833188f46b512fe993be